### PR TITLE
use unpack

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GHCNData"
 uuid = "7e11e036-0ca3-4a2d-a287-b6bec19ddff0"
 authors = ["Will Tebbutt and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/README.md
+++ b/README.md
@@ -15,15 +15,7 @@ If you use this data, you should acknowledge it appropriately. Instruction for d
 
 While the GHCN data is fairly straightforward, it's not as simple as just downloading a single file and opening it as a `DataFrame`.
 There are a few different kinds of files that you need to be aware of, each of which has a well-documented but non-standard format.
-As such, it makes sense to implement the functionality to load the files in a format more ammenable to standard workflows.
-
-
-
-# Requirements
-
-Presently, this package assumes that you have `tar` installed on your system.
-If this isn't true for you system, please either install it or open an issue (probably this package should be using [`Tar.jl`](https://github.com/JuliaIO/Tar.jl) anyway -- I'll make this change if people need it).
-
+As such, it makes sense to implement the functionality to load the files in a format more amenable to standard workflows.
 
 
 # Usage

--- a/src/datadeps.jl
+++ b/src/datadeps.jl
@@ -35,14 +35,6 @@ Name of the file containing all of the ghcn daily data.
 const ghcnd_data = "ghcnd_all.tar.gz"
 const ghcnd_data_dir = "ghcnd_all"
 
-"""
-    uncompress_all_data(fname=$ghcnd_data)
-
-`download_all_data` obtained a `tar.gz`. This function uncompresses it.
-"""
-function uncompress_all_data(fname=ghcnd_data)
-    unpack(fname)
-end
 
 # As per the suggestion in the DataDeps doc, we perform DataDep registration in __init__.
 function __init__()

--- a/src/datadeps.jl
+++ b/src/datadeps.jl
@@ -36,13 +36,12 @@ const ghcnd_data = "ghcnd_all.tar.gz"
 const ghcnd_data_dir = "ghcnd_all"
 
 """
-    uncompress_all_data(fname="ghcnd_all.tar.gz")
+    uncompress_all_data(fname=$ghcnd_data)
 
-`download_all_data` obtained a `tar.gz`. This function uncompresses it. Assumes a working
-installation of tar.
+`download_all_data` obtained a `tar.gz`. This function uncompresses it.
 """
-function uncompress_all_data(fname="ghcnd_all.tar.gz")
-    run(`tar xzvf $(ghcnd_data * "tar.gz")`)
+function uncompress_all_data(fname=ghcnd_data)
+    unpack(fname)
 end
 
 # As per the suggestion in the DataDeps doc, we perform DataDep registration in __init__.
@@ -66,6 +65,6 @@ function __init__()
         "ghcn-data",
         "GHCN country codes.",
         ghcn_root_dir * ghcnd_data,
-        post_fetch_method=(local_filepath) -> run(`tar xzvf $(local_filepath)`),
+        post_fetch_method=unpack,
     ))
 end


### PR DESCRIPTION
DataDeps.jl includes a `unpack` function that will correctly unpack any achive.
It now even uses lib7zip distributed as an artifact, thanks to recent PRs.
So it will work everywhere